### PR TITLE
Fix typo: MyMuPDF => PyMuPDF

### DIFF
--- a/run_chunkllama_100k.py
+++ b/run_chunkllama_100k.py
@@ -2,7 +2,7 @@
 try:
     import fitz  # PyMuPDF
 except ImportError:
-    print("run: pip install MyMuPDF")
+    print("run: pip install PyMuPDF")
 
 import os
 
@@ -77,13 +77,13 @@ B_SYS, E_SYS = "<<SYS>>\n", "\n<</SYS>>\n\n"
 for i in range(100):
     question = input("User: ")
     message = B_INST + B_SYS + sys_prompt + E_SYS + content + f"Question:\n{question}" + E_INST + "Answer:\n"
-    
+
     prompt_length = tokenizer(message, return_tensors="pt").input_ids.size()[-1]
     if prompt_length > args.max_length:
         print("="*20)
         print(f"Your input length is {prompt_length}, and it will be truncated to {args.max_length}. You can set `--max_length` to a larger value ")
         print("="*20)
-    
+
     inputs = tokenizer(message, truncation=True, return_tensors="pt").to(model.device)
     inp_length = inputs.input_ids.size()[-1]
     sample = model.generate(**inputs, do_sample=False, max_new_tokens=32)

--- a/run_together_200k.py
+++ b/run_together_200k.py
@@ -2,7 +2,7 @@
 try:
     import fitz  # PyMuPDF
 except ImportError:
-    print("run: pip install MyMuPDF")
+    print("run: pip install PyMuPDF")
 
 import os
 

--- a/run_vicuna_200k.py
+++ b/run_vicuna_200k.py
@@ -2,7 +2,7 @@
 try:
     import fitz  # PyMuPDF
 except ImportError:
-    print("run: pip install MyMuPDF")
+    print("run: pip install PyMuPDF")
 
 import os
 


### PR DESCRIPTION
This PR fixes a single-character typo in the library name.

| Before (MyMuPDF does not exist) | After (using correct name PyMuPDF) |
| - | - |
| <img width="703" alt="Screenshot 2024-02-29 at 1 20 39 AM" src="https://github.com/HKUNLP/ChunkLlama/assets/15131271/12fc5989-d3f8-459c-939a-a86556f57cbb"> | <img width="740" alt="Screenshot 2024-02-29 at 1 20 27 AM" src="https://github.com/HKUNLP/ChunkLlama/assets/15131271/74d52c64-e7cc-49ac-b7dc-ff8f8d07791c"> |

**Test plan:**

- [x] I ran `run_vicuna_200k.py`, and verified it got all the way to the part where I see the chat prompt