### PR TITLE
Add gitignore file to ignore Mac OSX .DS_Store and Python temp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+venv
+__pycache__


### PR DESCRIPTION
This PR ignores common Mac OSX .DS_Store and Python temp files that should never be uploaded to a repo (I use venv on a Macbook).

| Before (irrelevant files show in git status) | After (cleaner repo) |
| - | - |
| <img width="211" alt="Screenshot 2024-02-29 at 1 40 23 AM" src="https://github.com/HKUNLP/ChunkLlama/assets/15131271/6a04ce09-e4fb-4b86-a3e6-653c6f2b4bca"> | <img width="223" alt="Screenshot 2024-02-29 at 1 40 04 AM" src="https://github.com/HKUNLP/ChunkLlama/assets/15131271/26ac7c09-d280-4b20-8883-ff59e56489b9"> |

**Test plan:**

- [x] Verified on my VSCode that venv files no longer show up